### PR TITLE
Remove unused import in ingestapp.py

### DIFF
--- a/02_ingest/monthlyupdate/ingestapp.py
+++ b/02_ingest/monthlyupdate/ingestapp.py
@@ -19,7 +19,6 @@ import logging
 import ingest_flights
 
 import flask
-import google.cloud.storage as gcs
 
 # [start config]
 app = flask.Flask(__name__)


### PR DESCRIPTION
I found that `google.cloud.storage` is unused in `02_ingest/monthlyupdate/ingestapp.py`