### PR TITLE
Update to latest version of BigQuery Python client library

### DIFF
--- a/04_streaming/simulate/simulate.py
+++ b/04_streaming/simulate/simulate.py
@@ -105,9 +105,9 @@ WHERE
 ORDER BY
   NOTIFY_TIME ASC
 """
-   rows = bqclient.query_rows(querystr.format(jitter,
-                                                   args.startTime,
-                                                   args.endTime))
+   rows = bqclient.query(querystr.format(jitter,
+                                         args.startTime,
+                                         args.endTime))
    
    # create one Pub/Sub notification topic for each type of event
    publisher = pubsub.PublisherClient()


### PR DESCRIPTION
The `query_rows()` method no longer exists as of version 0.29.0. This line raises an error when run from the cloud shell because the installed version is 1.3.0.

This PR is follow up on https://github.com/GoogleCloudPlatform/data-science-on-gcp/issues/27