### PR TITLE
Added dependency for 04_streaming exercises.

### DIFF
--- a/04_streaming/simulate/install_packages.sh
+++ b/04_streaming/simulate/install_packages.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 sudo pip install --upgrade timezonefinder pytz apache-beam 'apache-beam[gcp]'
+sudo pip install google-cloud-dataflow


### PR DESCRIPTION
In PR added missing dependency for the exercises.

Though it doesn't appear to work properly for --upgrade flag as it seem to complain about version conflict so was made as separate line.

Related issue:
https://github.com/GoogleCloudPlatform/data-science-on-gcp/issues/34
Suggested answer from #34 doesn't seem to work or require more investigation.