### PR TITLE
#43 Fix the SQL for python script

### DIFF
--- a/07_sparkml/experiment.py
+++ b/07_sparkml/experiment.py
@@ -49,7 +49,7 @@ traindays.createOrReplaceTempView('traindays')
 # logistic regression
 trainquery = """
 SELECT
-  DEP_DELAY, TAXI_OUT, ARR_DELAY, DISTANCE
+  DEP_DELAY, TAXI_OUT, ARR_DELAY, DISTANCE, DEP_TIME, DEP_AIRPORT_TZOFFSET
 FROM flights f
 JOIN traindays t
 ON f.FL_DATE == t.FL_DATE


### PR DESCRIPTION
Added columns which are used in the python script to the SQL.

```
Original:
SELECT
  DEP_DELAY, TAXI_OUT, ARR_DELAY, DISTANCE
FROM flights f
...

Updated:
SELECT
  DEP_DELAY, TAXI_OUT, ARR_DELAY, DISTANCE, DEP_TIME, DEP_AIRPORT_TZOFFSET
FROM flights f
...
```

With this change, the command in README.md "./submit_spark.sh [BUCKET] experiment.py" finishes without any errors.

This is the follow-up for the [issue #43 ](https://github.com/GoogleCloudPlatform/data-science-on-gcp/issues/43).