### PR TITLE
Update install_packages.sh

### DIFF
--- a/04_streaming/simulate/install_packages.sh
+++ b/04_streaming/simulate/install_packages.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo pip install --upgrade timezonefinder pytz 'apache-beam[gcp]'
+sudo pip install --upgrade timezonefinder==3.0.0 pytz 'apache-beam[gcp]'


### PR DESCRIPTION
The latest versions of timezonefinder do not work with the df02.py script. So need to ensure that previous version is used. Therefore I added "==3.0.0" to the pip install statement.