### PR TITLE
Minor updates for Python3

### DIFF
--- a/04_streaming/simulate/df05.py
+++ b/04_streaming/simulate/df05.py
@@ -41,7 +41,7 @@ def as_utc(date, hhmm, tzone):
       else:
          return '',0 # empty string corresponds to canceled flights
    except ValueError as e:
-      print '{} {} {}'.format(date, hhmm, tzone)
+      print ('{} {} {}'.format(date, hhmm, tzone))
       raise e
 
 def add_24h_if_before(arrtime, deptime):

--- a/04_streaming/simulate/df06.py
+++ b/04_streaming/simulate/df06.py
@@ -41,7 +41,7 @@ def as_utc(date, hhmm, tzone):
       else:
          return '',0 # empty string corresponds to canceled flights
    except ValueError as e:
-      print '{} {} {}'.format(date, hhmm, tzone)
+      print ('{} {} {}'.format(date, hhmm, tzone))
       raise e
 
 def add_24h_if_before(arrtime, deptime):
@@ -166,6 +166,6 @@ if __name__ == '__main__':
    parser.add_argument('-d','--dataset', help='BigQuery dataset', default='flights')
    args = vars(parser.parse_args())
 
-   print "Correcting timestamps and writing to BigQuery dataset {}".format(args['dataset'])
+   print ("Correcting timestamps and writing to BigQuery dataset {}".format(args['dataset']))
   
    run(project=args['project'], bucket=args['bucket'], dataset=args['dataset'])

--- a/04_streaming/simulate/setup.py
+++ b/04_streaming/simulate/setup.py
@@ -76,14 +76,14 @@ class CustomCommands(setuptools.Command):
     pass
 
   def RunCustomCommand(self, command_list):
-    print 'Running command: %s' % command_list
+    print ('Running command: %s' % command_list)
     p = subprocess.Popen(
         command_list,
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     # Can use communicate(input='y\n'.encode()) if the command run requires
     # some confirmation.
     stdout_data, _ = p.communicate()
-    print 'Command output: %s' % stdout_data
+    print ('Command output: %s' % stdout_data)
     if p.returncode != 0:
       raise RuntimeError(
           'Command %s failed: exit code: %s' % (command_list, p.returncode))


### PR DESCRIPTION
-As the latest or older release for timezonefinder does not work with Python2.7 version and df05.py, df06.py scripts.
-An older release is able to create a Dataflow job which leads to an error in processing steps.