### PR TITLE
Fix error when running 04_streaming/simulate/df06.py on own GCP platform account #58

### DIFF
--- a/04_streaming/simulate/setup.py
+++ b/04_streaming/simulate/setup.py
@@ -98,7 +98,7 @@ class CustomCommands(setuptools.Command):
 # so this dependency will not trigger anything to be installed unless a version
 # restriction is specified.
 REQUIRED_PACKAGES = [
-    'timezonefinder',
+    'timezonefinder==3.0.0',
     'pytz'
     ]
 


### PR DESCRIPTION
The latest versions of timezonefinder do not work with the df06.py script when executed on Cloud Dataflow using one's own GCP platform account. Added same fix as #54 to setup.py.