### PR TITLE
Modifying the print function for python2 and python3.

### DIFF
--- a/04_streaming/simulate/df04.py
+++ b/04_streaming/simulate/df04.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import apache_beam as beam
 import csv
 
@@ -39,7 +40,7 @@ def as_utc(date, hhmm, tzone):
       else:
          return '',0 # empty string corresponds to canceled flights
    except ValueError as e:
-      print '{} {} {}'.format(date, hhmm, tzone)
+      print('{} {} {}'.format(date, hhmm, tzone))
       raise e
 
 def add_24h_if_before(arrtime, deptime):

--- a/07_sparkml_and_bqml/experiment.py
+++ b/07_sparkml_and_bqml/experiment.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from pyspark.mllib.classification import LogisticRegressionWithLBFGS
 from pyspark.mllib.regression import LabeledPoint
 from pyspark.sql import SparkSession
@@ -146,5 +147,5 @@ def eval(labelpred):
             'correct_noncancel': float(corr_nocancel)/nocancel_denom, \
             'rmse': np.sqrt(totsqe/float(cancel_denom + nocancel_denom))
            }
-print eval(labelpred)
+print(eval(labelpred))
 

--- a/07_sparkml_and_bqml/experimentation.ipynb
+++ b/07_sparkml_and_bqml/experimentation.ipynb
@@ -30,6 +30,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function\n",
     "from pyspark.mllib.classification import LogisticRegressionWithLBFGS\n",
     "from pyspark.mllib.regression import LabeledPoint"
    ]
@@ -244,7 +245,7 @@
    ],
    "source": [
     "lrmodel = LogisticRegressionWithLBFGS.train(examples, intercept=True)\n",
-    "print lrmodel.weights,lrmodel.intercept"
+    "print(lrmodel.weights,lrmodel.intercept)"
    ]
   },
   {
@@ -293,7 +294,7 @@
    ],
    "source": [
     "evalquery = trainquery.replace(\"t.holdout == False\",\"t.holdout == True\")\n",
-    "print evalquery"
+    "print(evalquery)"
    ]
   },
   {
@@ -353,7 +354,7 @@
    ],
    "source": [
     "labelpred = examples.map(lambda p: (p.label, lrmodel.predict(p.features)))\n",
-    "print eval(labelpred)"
+    "print(eval(labelpred))"
    ]
   },
   {

--- a/07_sparkml_and_bqml/logistic.py
+++ b/07_sparkml_and_bqml/logistic.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from pyspark.mllib.classification import LogisticRegressionWithLBFGS
 from pyspark.mllib.regression import LabeledPoint
 from pyspark.sql import SparkSession
@@ -97,11 +98,11 @@ def eval(labelpred):
 # Evaluate model
 lrmodel.clearThreshold() # so it returns probabilities
 labelpred = examples.map(lambda p: (p.label, lrmodel.predict(p.features)))
-print 'All flights:'
-print eval(labelpred)
+print('All flights:')
+print(eval(labelpred))
 
 # keep only those examples near the decision threshold
-print 'Flights near decision threshold:'
+print('Flights near decision threshold:')
 labelpred = labelpred.filter(lambda (label, pred): pred > 0.65 and pred < 0.75)
-print eval(labelpred)
+print(eval(labelpred))
 

--- a/07_sparkml_and_bqml/logistic_regression.ipynb
+++ b/07_sparkml_and_bqml/logistic_regression.ipynb
@@ -41,6 +41,7 @@
    "source": [
     "# Create spark session\n",
     "\n",
+    "from __future__ import print_function\n",
     "from pyspark.sql import SparkSession\n",
     "from pyspark import SparkContext\n",
     "\n",
@@ -50,8 +51,8 @@
     "    .appName(\"Logistic regression w/ Spark ML\") \\\n",
     "    .getOrCreate()\n",
     "\n",
-    "print spark\n",
-    "print sc"
+    "print(spark)\n",
+    "print(sc)"
    ]
   },
   {
@@ -197,7 +198,7 @@
     }
    ],
    "source": [
-    "print traindata.head(2)  # if this is empty, try changing the shard you are using."
+    "print(traindata.head(2))  # if this is empty, try changing the shard you are using."
    ]
   },
   {
@@ -368,7 +369,7 @@
    ],
    "source": [
     "lrmodel = LogisticRegressionWithLBFGS.train(examples, intercept=True)\n",
-    "print lrmodel.weights,lrmodel.intercept"
+    "print(lrmodel.weights,lrmodel.intercept)"
    ]
   },
   {
@@ -388,8 +389,8 @@
     }
    ],
    "source": [
-    "print lrmodel.predict([6.0,12.0,594.0])\n",
-    "print lrmodel.predict([36.0,12.0,594.0])"
+    "print(lrmodel.predict([6.0,12.0,594.0]))\n",
+    "print(lrmodel.predict([36.0,12.0,594.0]))"
    ]
   },
   {
@@ -410,8 +411,8 @@
    ],
    "source": [
     "lrmodel.clearThreshold()\n",
-    "print lrmodel.predict([6.0,12.0,594.0])\n",
-    "print lrmodel.predict([36.0,12.0,594.0])"
+    "print(lrmodel.predict([6.0,12.0,594.0]))\n",
+    "print(lrmodel.predict([36.0,12.0,594.0]))"
    ]
   },
   {
@@ -432,8 +433,8 @@
    ],
    "source": [
     "lrmodel.setThreshold(0.7) # cancel if prob-of-ontime < 0.7\n",
-    "print lrmodel.predict([6.0,12.0,594.0])\n",
-    "print lrmodel.predict([36.0,12.0,594.0])"
+    "print(lrmodel.predict([6.0,12.0,594.0]))\n",
+    "print(lrmodel.predict([36.0,12.0,594.0]))"
    ]
   },
   {
@@ -476,7 +477,7 @@
    "outputs": [],
    "source": [
     "lrmodel.save(sc, MODEL_FILE)\n",
-    "print '{} saved'.format(MODEL_FILE)"
+    "print('{} saved'.format(MODEL_FILE))"
    ]
   },
   {
@@ -496,7 +497,7 @@
    ],
    "source": [
     "lrmodel = 0\n",
-    "print lrmodel"
+    "print(lrmodel)"
    ]
   },
   {
@@ -535,7 +536,7 @@
     }
    ],
    "source": [
-    "print lrmodel.predict([36.0,12.0,594.0])"
+    "print(lrmodel.predict([36.0,12.0,594.0]))"
    ]
   },
   {
@@ -554,7 +555,7 @@
     }
    ],
    "source": [
-    "print lrmodel.predict([8.0,4.0,594.0])"
+    "print(lrmodel.predict([8.0,4.0,594.0]))"
    ]
   },
   {
@@ -583,7 +584,7 @@
    ],
    "source": [
     "lrmodel.clearThreshold() # to make the model produce probabilities\n",
-    "print lrmodel.predict([20, 10, 500])"
+    "print(lrmodel.predict([20, 10, 500]))"
    ]
   },
   {
@@ -714,7 +715,7 @@
     "            .csv(inputs)\n",
     "flights.createOrReplaceTempView('flights')\n",
     "testquery = trainquery.replace(\"t.is_train_day == 'True'\",\"t.is_train_day == 'False'\")\n",
-    "print testquery"
+    "print(testquery)"
    ]
   },
   {
@@ -797,13 +798,13 @@
     "# Evaluate model\n",
     "lrmodel.clearThreshold() # so it returns probabilities\n",
     "labelpred = examples.map(lambda p: (p.label, lrmodel.predict(p.features)))\n",
-    "print 'All flights:'\n",
-    "print eval(labelpred)\n",
+    "print('All flights:')\n",
+    "print(eval(labelpred))\n",
     "\n",
     "# keep only those examples near the decision threshold\n",
-    "print 'Flights near decision threshold:'\n",
+    "print('Flights near decision threshold:')\n",
     "labelpred = labelpred.filter(lambda (label, pred): pred > 0.65 and pred < 0.75)\n",
-    "print eval(labelpred)"
+    "print(eval(labelpred))ß"
    ]
   },
   {

--- a/10_realtime/distributions.ipynb
+++ b/10_realtime/distributions.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function\n",
     "import google.datalab.bigquery as bq\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
@@ -134,7 +135,7 @@
     "  1000\n",
     "\"\"\".format(js).replace('\\n', ' ')\n",
     "\n",
-    "print sql\n",
+    "print(sql)\n",
     "df = bq.Query(sql).execute().result().to_dataframe()\n",
     "sns.distplot(df['JITTER'], kde=True);"
    ]


### PR DESCRIPTION
1. Adding the print_function from the `__future__` package to support both python2 and python3 for calling `print()`.
2. Porting Python2 `print` to `print()`.