### PR TITLE
SSL cipher to access url

### DIFF
--- a/02_ingest/monthlyupdate/ingest_flights.py
+++ b/02_ingest/monthlyupdate/ingest_flights.py
@@ -26,9 +26,15 @@ from google.cloud.storage import Blob
 
 try:
     from urllib.request import urlopen as impl
+    import ssl
+
+    ctx_no_secure = ssl.create_default_context()
+    ctx_no_secure.set_ciphers('HIGH:!DH:!aNULL')
+    ctx_no_secure.check_hostname = False
+    ctx_no_secure.verify_mode = ssl.CERT_NONE
     # For Python 3.0 and later
     def urlopen(url, data):
-        return impl(url, data.encode('utf-8'))
+        return impl(url, data.encode('utf-8'), context=ctx_no_secure)
     def remove_quote(text):
         return text.translate(str.maketrans('','', '"'))
 except ImportError as error:


### PR DESCRIPTION
The examples from the '02_ingest' folder are used for a Qwiklabs lab called "Ingesting Data Into The Cloud Using Google Cloud Functions". When running this code in cloud shell, the ingest_flights.py file gives an ssl error: dh key too small. These changes fix the error and make the lab run correctly.

If this change is unwanted for the whole repo, let me know! I can use a forked repo for the lab instead.